### PR TITLE
Required assoc_type in 2.0 associations

### DIFF
--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -425,11 +425,20 @@ class AssociateRequest(OpenIDRequest):
                             'assocaition session type. Continuing anyway.')
             elif not session_type:
                 session_type = 'no-encryption'
+
+            # in 1.0 assoc_type has default
+            assoc_type = message.getArg(OPENID_NS, 'assoc_type', 'HMAC-SHA1')
         else:
             session_type = message.getArg(OPENID2_NS, 'session_type')
             if session_type is None:
                 raise ProtocolError(message,
                                     text="session_type missing from request")
+
+            # in 2.0 assoc_type is required
+            assoc_type = message.getArg(OPENID2_NS, 'assoc_type')
+            if assoc_type is None:
+                raise ProtocolError(message,
+                                    text="assoc_type missing from request")
 
         try:
             session_class = klass.session_classes[session_type]
@@ -443,7 +452,6 @@ class AssociateRequest(OpenIDRequest):
             raise ProtocolError(message, 'Error parsing %s session: %s' %
                                 (session_class.session_type, why[0]))
 
-        assoc_type = message.getArg(OPENID_NS, 'assoc_type', 'HMAC-SHA1')
         if assoc_type not in session.allowed_assoc_types:
             fmt = 'Session type %s does not support association type %s'
             raise ProtocolError(message, fmt % (session_type, assoc_type))

--- a/openid/test/test_server.py
+++ b/openid/test/test_server.py
@@ -709,6 +709,7 @@ class TestEncode(unittest.TestCase):
     def test_assocReply(self):
         msg = Message(OPENID2_NS)
         msg.setArg(OPENID2_NS, 'session_type', 'no-encryption')
+        msg.setArg(OPENID2_NS, 'assoc_type', 'HMAC-SHA1')
         request = server.AssociateRequest.fromMessage(msg)
         response = server.OpenIDResponse(request)
         response.fields = Message.fromPostArgs(
@@ -834,6 +835,7 @@ class TestSigningEncode(unittest.TestCase):
     def test_assocReply(self):
         msg = Message(OPENID2_NS)
         msg.setArg(OPENID2_NS, 'session_type', 'no-encryption')
+        msg.setArg(OPENID2_NS, 'assoc_type', 'HMAC-SHA1')
         request = server.AssociateRequest.fromMessage(msg)
         response = server.OpenIDResponse(request)
         response.fields = Message.fromOpenIDArgs({'assoc_handle': "every-zig"})
@@ -1702,6 +1704,7 @@ class TestServer(unittest.TestCase, CatchLogs):
         msg = Message.fromPostArgs({
             'openid.ns': OPENID2_NS,
             'openid.session_type': 'no-encryption',
+            'openid.assoc_type': 'HMAC-SHA1',
             })
 
         request = server.AssociateRequest.fromMessage(msg)
@@ -1724,6 +1727,7 @@ class TestServer(unittest.TestCase, CatchLogs):
         msg = Message.fromPostArgs({
             'openid.ns': OPENID2_NS,
             'openid.session_type': 'no-encryption',
+            'openid.assoc_type': 'HMAC-SHA1',
             })
 
         request = server.AssociateRequest.fromMessage(msg)
@@ -1761,6 +1765,16 @@ class TestServer(unittest.TestCase, CatchLogs):
         """Make sure session_type is required in OpenID 2"""
         msg = Message.fromPostArgs({
             'openid.ns': OPENID2_NS,
+            })
+
+        self.assertRaises(server.ProtocolError,
+                          server.AssociateRequest.fromMessage, msg)
+
+    def test_missingAssocTypeOpenID2(self):
+        """Make sure assoc_type is required in OpenID 2"""
+        msg = Message.fromPostArgs({
+            'openid.ns': OPENID2_NS,
+            'openid.session_type': 'no-encryption',
             })
 
         self.assertRaises(server.ProtocolError,


### PR DESCRIPTION
In specification 2.0 assoc_type parameter of association request is required and can not be omitted.
