### PR TITLE
Updated MySql storage driver

### DIFF
--- a/openid/store/sqlstore.py
+++ b/openid/store/sqlstore.py
@@ -374,12 +374,11 @@ class MySQLStore(SQLStore):
 
     create_nonce_sql = """
     CREATE TABLE %(nonces)s (
-        server_url BLOB NOT NULL,
+        server_url VARCHAR(255) NOT NULL,
         timestamp INTEGER NOT NULL,
         salt CHAR(40) NOT NULL,
         PRIMARY KEY (server_url(255), timestamp, salt)
-    )
-    ENGINE=InnoDB;
+    );
     """
 
     create_assoc_sql = """
@@ -387,13 +386,12 @@ class MySQLStore(SQLStore):
     (
         server_url BLOB NOT NULL,
         handle VARCHAR(255) NOT NULL,
-        secret BLOB NOT NULL,
+        secret VARCHAR(255) NOT NULL,
         issued INTEGER NOT NULL,
         lifetime INTEGER NOT NULL,
         assoc_type VARCHAR(64) NOT NULL,
         PRIMARY KEY (server_url(255), handle)
-    )
-    ENGINE=InnoDB;
+    );
     """
 
     set_assoc_sql = ('REPLACE INTO %(associations)s '

--- a/openid/store/sqlstore.py
+++ b/openid/store/sqlstore.py
@@ -13,6 +13,8 @@ from openid.association import Association
 from openid.store.interface import OpenIDStore
 from openid.store import nonce
 
+from base64 import b64encode, b64decode
+
 def _inTxn(func):
     def wrapped(self, *args, **kwargs):
         return self._callInTransaction(func, self, *args, **kwargs)
@@ -414,12 +416,11 @@ class MySQLStore(SQLStore):
     clean_nonce_sql = 'DELETE FROM %(nonces)s WHERE timestamp < %%s;'
 
     def blobDecode(self, blob):
-        if type(blob) is str:
-            # Versions of MySQLdb >= 1.2.2
-            return blob
-        else:
-            # Versions of MySQLdb prior to 1.2.2 (as far as we can tell)
-            return blob.tostring()
+        return b64decode(blob)
+
+    def blobEncode(self, s):
+        return b64encode(s)
+
 
 class PostgreSQLStore(SQLStore):
     """


### PR DESCRIPTION
I've made mysql storage driver compatible with ndbcluster storage engine by changing schema and switching blobEncode/blobDecode methods to work via the base64 encoder.
