### PR TITLE
add oauth extension

### DIFF
--- a/openid/extensions/oauth.py
+++ b/openid/extensions/oauth.py
@@ -50,7 +50,7 @@ class OAuthResponse(Extension):
     @classmethod
     def fromSuccessResponse(cls, success_response, signed=True):
         args = success_response.getSignedNS(NS_URI)
-        if args == {}:
+        if args == None:
             return None
         oauth_response = cls()
         oauth_response.parseExtensionArgs(args)

--- a/openid/extensions/oauth.py
+++ b/openid/extensions/oauth.py
@@ -1,0 +1,72 @@
+#An Implementation of the OpenID OAuth Extension
+
+from openid.extension import Extension
+
+NS_URI = "http://specs.openid.net/extensions/oauth/1.0"
+class OAuthRequest(Extension):
+    # An OAuth token request, sent from a relying
+    # party to a provider
+    def __init__(self, consumer=None, scope=None):
+        self.ns_alias = "oauth"
+        self.ns_uri = NS_URI
+        self.consumer = consumer
+        self.scope = scope
+
+    def getExtensionArgs(self):
+        ns_args = {}
+        ns_args['consumer'] = self.consumer
+        ns_args['scope'] = self.scope
+        return ns_args
+
+    # Instantiate a Request object from the arguments in a
+    # checkid_* OpenID message
+    # return nil if the extension was not requested.
+
+    @classmethod
+    def fromOpenIDRequest(cls, openid_request):
+        oauth_request = cls()
+        args = openid_request.message.get_args(NS_URI)
+        if args == {}:
+          return None
+        oauth_request.parseExtensionArgs(args)
+        return oauth_request
+
+    # Set the state of this request to be that expressed in these
+    # OAuth arguments
+    def parseExtensionArgs(args):
+        self.consumer = args['consumer']
+        self.scope = args['scope']
+
+# A OAuth request token response, sent from a provider
+# to a relying party
+class OAuthResponse(Extension):
+    def __init__(self, request_token=None, scope=None):
+        self.ns_alias = "oauth"
+        self.ns_uri = NS_URI
+        self.request_token = request_token
+        self.scope = scope
+        
+    # Create a Response object from an openid.consumer.consumer.SuccessResponse
+    @classmethod
+    def fromSuccessResponse(cls, success_response, signed=True):
+        args = success_response.getSignedNS(NS_URI)
+        if args == {}:
+            return None
+        oauth_response = cls()
+        oauth_response.parseExtensionArgs(args)
+        return oauth_response
+
+    # parse the oauth request arguments into the
+    # internal state of this object
+    # if strict is specified, raise an exception when bad data is
+    # encountered
+    def parseExtensionArgs(self, args, strict=False):
+        self.request_token = args['request_token']
+        self.scope = args['scope']
+
+    def getExtensionArgs(self):
+        ns_args = {}
+        ns_args['request_token'] = self.request_token
+        ns_args['scope'] = self.scope
+        return ns_args
+


### PR DESCRIPTION
python-openid doesn't have oauth extension yet.
So I create oauth.py, porting from ruby-openid's oauth.rb, and check it can work.
