### PR TITLE
Provider should post automatically to Consumer after authorize

### DIFF
--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -1339,7 +1339,7 @@ class Encoder(object):
                                       headers={'location': location})
         elif encode_as == ENCODE_HTML_FORM:
             wr = self.responseFactory(code=HTTP_OK,
-                                      body=response.toFormMarkup())
+                                      body=response.toHTML())
         else:
             # Can't encode this to a protocol message.  You should probably
             # render it to HTML and show it to the user.


### PR DESCRIPTION
Long ago, 8bad9e2 added toHTML function to OpenIdResponse so the form posts automatically upon redirection. Yet, the encoder still uses the toFormMarkup function directly.

Please pull this commit to enable automatic post saving the burden of clicking on continue everytime.
