### PR TITLE
Use setuptools, if present.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import sys
 import os
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 if 'sdist' in sys.argv:
     os.system('./admin/makedoc')


### PR DESCRIPTION
This change enables usage such as '/path/to/python setup.py develop' (i.e.,
installing a checkout into site-packages).  It falls back to stock distutils
if setuptools is not importable.
