### PR TITLE
Changed over to logging module from built-in logging module

### DIFF
--- a/openid/consumer/discover.py
+++ b/openid/consumer/discover.py
@@ -14,8 +14,9 @@ __all__ = [
     ]
 
 import urlparse
+import logging
 
-from openid import oidutil, fetchers, urinorm
+from openid import fetchers, urinorm
 
 from openid import yadis
 from openid.yadis.etxrd import nsTag, XRDSError, XRD_NS_2_0
@@ -425,7 +426,7 @@ def discoverXRI(iname):
         for service_element in services:
             endpoints.extend(flt.getServiceEndpoints(iname, service_element))
     except XRDSError:
-        oidutil.log('xrds error on ' + iname)
+        logging.exception('xrds error on ' + iname)
 
     for endpoint in endpoints:
         # Is there a way to pass this through the filter to the endpoint

--- a/openid/extensions/sreg.py
+++ b/openid/extensions/sreg.py
@@ -38,7 +38,7 @@ OpenID providers.
 from openid.message import registerNamespaceAlias, \
      NamespaceAliasRegistrationError
 from openid.extension import Extension
-from openid import oidutil
+import logging
 
 try:
     basestring #pylint:disable-msg=W0104
@@ -95,7 +95,7 @@ ns_uri = ns_uri_1_1
 try:
     registerNamespaceAlias(ns_uri_1_1, 'sreg')
 except NamespaceAliasRegistrationError, e:
-    oidutil.log('registerNamespaceAlias(%r, %r) failed: %s' % (ns_uri_1_1,
+    logging.exception('registerNamespaceAlias(%r, %r) failed: %s' % (ns_uri_1_1,
                                                                'sreg', str(e),))
 
 def supportsSReg(endpoint):

--- a/openid/kvform.py
+++ b/openid/kvform.py
@@ -1,8 +1,7 @@
 __all__ = ['seqToKV', 'kvToSeq', 'dictToKV', 'kvToDict']
 
-from openid import oidutil
-
 import types
+import logging
 
 class KVFormError(ValueError):
     pass
@@ -22,7 +21,7 @@ def seqToKV(seq, strict=False):
         if strict:
             raise KVFormError(formatted)
         else:
-            oidutil.log(formatted)
+            logging.warn(formatted)
 
     lines = []
     for k, v in seq:
@@ -73,7 +72,7 @@ def kvToSeq(data, strict=False):
         if strict:
             raise KVFormError(formatted)
         else:
-            oidutil.log(formatted)
+            logging.warn(formatted)
 
     lines = data.split('\n')
     if lines[-1]:

--- a/openid/oidutil.py
+++ b/openid/oidutil.py
@@ -10,6 +10,7 @@ __all__ = ['log', 'appendArgs', 'toBase64', 'fromBase64', 'autoSubmitHTML']
 import binascii
 import sys
 import urlparse
+import logging
 
 from urllib import urlencode
 
@@ -65,9 +66,8 @@ def importElementTree(module_names=None):
             except (SystemExit, MemoryError, AssertionError):
                 raise
             except:
-                why = sys.exc_info()[1]
-                log('Not using ElementTree library %r because it failed to '
-                    'parse a trivial document: %s' % (mod_name, why))
+                logging.exception('Not using ElementTree library %r because it failed to '
+                    'parse a trivial document: %s' % mod_name)
             else:
                 return ElementTree
     else:
@@ -79,20 +79,8 @@ def importElementTree(module_names=None):
 def log(message, level=0):
     """Handle a log message from the OpenID library.
 
-    This implementation writes the string it to C{sys.stderr},
-    followed by a newline.
-
-    Currently, the library does not use the second parameter to this
-    function, but that may change in the future.
-
-    To install your own logging hook::
-
-      from openid import oidutil
-
-      def myLoggingFunction(message, level):
-          ...
-
-      oidutil.log = myLoggingFunction
+    This is a legacy function which redirects to logging.error.
+    The logging module should be used instead of this
 
     @param message: A string containing a debugging message from the
         OpenID library
@@ -106,8 +94,8 @@ def log(message, level=0):
     @returns: Nothing.
     """
 
-    sys.stderr.write(message)
-    sys.stderr.write('\n')
+    logging.error("This is a legacy log message, please use the "
+      "logging module. Message: %s", message)
 
 def appendArgs(url, args):
     """Append query arguments to a HTTP(s) URL. If the URL already has

--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -117,6 +117,7 @@ From 1.1 to 2.0
 """
 
 import time, warnings
+import logging
 from copy import deepcopy
 
 from openid import cryptutil
@@ -420,7 +421,7 @@ class AssociateRequest(OpenIDRequest):
         if message.isOpenID1():
             session_type = message.getArg(OPENID_NS, 'session_type')
             if session_type == 'no-encryption':
-                oidutil.log('Received OpenID 1 request with a no-encryption '
+                logging.warn('Received OpenID 1 request with a no-encryption '
                             'assocaition session type. Continuing anyway.')
             elif not session_type:
                 session_type = 'no-encryption'
@@ -1170,7 +1171,7 @@ class Signatory(object):
         """
         assoc = self.getAssociation(assoc_handle, dumb=True)
         if not assoc:
-            oidutil.log("failed to get assoc with handle %r to verify "
+            logging.error("failed to get assoc with handle %r to verify "
                         "message %r"
                         % (assoc_handle, message))
             return False
@@ -1178,7 +1179,7 @@ class Signatory(object):
         try:
             valid = assoc.checkMessageSignature(message)
         except ValueError, ex:
-            oidutil.log("Error in verifying %s with %s: %s" % (message,
+            logging.exception("Error in verifying %s with %s: %s" % (message,
                                                                assoc,
                                                                ex))
             return False
@@ -1285,7 +1286,7 @@ class Signatory(object):
             key = self._normal_key
         assoc = self.store.getAssociation(key, assoc_handle)
         if assoc is not None and assoc.expiresIn <= 0:
-            oidutil.log("requested %sdumb key %r is expired (by %s seconds)" %
+            logging.info("requested %sdumb key %r is expired (by %s seconds)" %
                         ((not dumb) and 'not-' or '',
                          assoc_handle, assoc.expiresIn))
             if checkExpiration:

--- a/openid/server/trustroot.py
+++ b/openid/server/trustroot.py
@@ -17,12 +17,12 @@ __all__ = [
     'verifyReturnTo',
     ]
 
-from openid import oidutil
 from openid import urinorm
 from openid.yadis import services
 
 from urlparse import urlparse, urlunparse
 import re
+import logging
 
 ############################################
 _protocols = ['http', 'https']
@@ -443,12 +443,12 @@ def verifyReturnTo(realm_str, return_to, _vrfy=getAllowedReturnURLs):
     try:
         allowable_urls = _vrfy(realm.buildDiscoveryURL())
     except RealmVerificationRedirected, err:
-        oidutil.log(str(err))
+        logging.exception(str(err))
         return False
 
     if returnToMatches(allowable_urls, return_to):
         return True
     else:
-        oidutil.log("Failed to validate return_to %r for realm %r, was not "
+        logging.error("Failed to validate return_to %r for realm %r, was not "
                     "in %s" % (return_to, realm_str, allowable_urls))
         return False

--- a/openid/store/filestore.py
+++ b/openid/store/filestore.py
@@ -7,6 +7,7 @@ import string
 import os
 import os.path
 import time
+import logging
 
 from errno import EEXIST, ENOENT
 
@@ -371,7 +372,7 @@ class FileOpenIDStore(OpenIDStore):
                 association_file = file(association_filename, 'rb')
             except IOError, why:
                 if why.errno == ENOENT:
-                    oidutil.log("%s disappeared during %s._allAssocs" % (
+                    logging.exception("%s disappeared during %s._allAssocs" % (
                         association_filename, self.__class__.__name__))
                 else:
                     raise

--- a/openid/test/kvform.py
+++ b/openid/test/kvform.py
@@ -1,26 +1,19 @@
 from openid import kvform
-from openid import oidutil
+from openid.test.support import CatchLogs
 import unittest
 
-class KVBaseTest(unittest.TestCase):
+class KVBaseTest(unittest.TestCase, CatchLogs):
     def shortDescription(self):
         return '%s test for %r' % (self.__class__.__name__, self.kvform)
 
-    def log(self, message, unused_priority=None):
-        self.warnings.append(message)
-
     def checkWarnings(self, num_warnings):
-        self.failUnlessEqual(num_warnings, len(self.warnings), repr(self.warnings))
+        self.failUnlessEqual(num_warnings, len(self.messages), repr(self.messages))
 
     def setUp(self):
-        self.warnings = []
-        self.old_log = oidutil.log
-        self.log_func = oidutil.log = self.log
-        self.failUnless(self.log_func is oidutil.log,
-                        (oidutil.log, self.log_func))
+        CatchLogs.setUp(self)
 
     def tearDown(self):
-        oidutil.log = self.old_log
+        CatchLogs.tearDown(self)
 
 class KVDictTest(KVBaseTest):
     def __init__(self, kv, dct, warnings):
@@ -172,3 +165,8 @@ def pyUnitTests():
     tests.extend([KVExcTest(case) for case in kvexc_cases])
     tests.append(unittest.defaultTestLoader.loadTestsFromTestCase(GeneralTest))
     return unittest.TestSuite(tests)
+
+if __name__ == '__main__':
+    suite = pyUnitTests()
+    runner = unittest.TextTestRunner()
+    runner.run(suite)

--- a/openid/test/support.py
+++ b/openid/test/support.py
@@ -1,5 +1,17 @@
 from openid import message
-from openid import oidutil
+from logging.handlers import BufferingHandler
+import logging
+
+class TestHandler(BufferingHandler):
+    def __init__(self, messages):
+        BufferingHandler.__init__(self, 0)
+	self.messages = messages
+
+    def shouldFlush(self):
+        return False
+
+    def emit(self, record):
+        self.messages.append(record.__dict__)
 
 class OpenIDTestMixin(object):
     def failUnlessOpenIDValueEquals(self, msg, key, expected, ns=None):
@@ -21,15 +33,20 @@ class OpenIDTestMixin(object):
 
 class CatchLogs(object):
     def setUp(self):
-        self.old_logger = oidutil.log
-        oidutil.log = self.gotLogMessage
-        self.messages = []
+	self.messages = []
+	root_logger = logging.getLogger()
+	self.old_log_level = root_logger.getEffectiveLevel()
+	root_logger.setLevel(logging.DEBUG)
 
-    def gotLogMessage(self, message):
-        self.messages.append(message)
+	self.handler = TestHandler(self.messages)
+	formatter = logging.Formatter("%(message)s [%(asctime)s - %(name)s - %(levelname)s]")
+	self.handler.setFormatter(formatter)
+	root_logger.addHandler(self.handler)
 
     def tearDown(self):
-        oidutil.log = self.old_logger
+        root_logger = logging.getLogger()
+	root_logger.removeHandler(self.handler)
+	root_logger.setLevel(self.old_log_level)
 
     def failUnlessLogMatches(self, *prefixes):
         """
@@ -38,14 +55,15 @@ class CatchLogs(object):
         number of prefixes is different than the number of log
         messages.
         """
-        assert len(prefixes) == len(self.messages), \
+	messages = [r['msg'] for r in self.messages]
+	assert len(prefixes) == len(messages), \
                "Expected log prefixes %r, got %r" % (prefixes,
-                                                     self.messages)
+                                                     messages)
 
-        for prefix, message in zip(prefixes, self.messages):
+        for prefix, message in zip(prefixes, messages):
             assert message.startswith(prefix), \
                    "Expected log prefixes %r, got %r" % (prefixes,
-                                                         self.messages)
+                                                         messages)
 
     def failUnlessLogEmpty(self):
         self.failUnlessLogMatches()

--- a/openid/test/test_negotiation.py
+++ b/openid/test/test_negotiation.py
@@ -163,8 +163,8 @@ class TestOpenID1SessionNegotiation(unittest.TestCase, CatchLogs):
     Tests for the OpenID 1 consumer association session behavior.  See
     the docs for TestOpenID2SessionNegotiation.  Notice that this
     class is not a subclass of the OpenID 2 tests.  Instead, it uses
-    many of the same inputs but inspects the log messages logged with
-    oidutil.log.  See the calls to self.failUnlessLogMatches.  Some of
+    many of the same inputs but inspects the log messages.
+    See the calls to self.failUnlessLogMatches.  Some of
     these tests pass openid2-style messages to the openid 1
     association processing logic to be sure it ignores the extra data.
     """

--- a/openid/test/test_server.py
+++ b/openid/test/test_server.py
@@ -5,6 +5,7 @@ from openid import association, cryptutil, oidutil
 from openid.message import Message, OPENID_NS, OPENID2_NS, OPENID1_NS, \
      IDENTIFIER_SELECT, no_default, OPENID1_URL_LIMIT
 from openid.store import memstore
+from openid.test.support import CatchLogs
 import cgi
 
 import unittest
@@ -20,18 +21,6 @@ from urlparse import urlparse
 
 ALT_MODULUS = 0xCAADDDEC1667FC68B5FA15D53C4E1532DD24561A1A2D47A12C01ABEA1E00731F6921AAC40742311FDF9E634BB7131BEE1AF240261554389A910425E044E88C8359B010F5AD2B80E29CB1A5B027B19D9E01A6F63A6F45E5D7ED2FF6A2A0085050A7D0CF307C3DB51D2490355907B4427C23A98DF1EB8ABEF2BA209BB7AFFE86A7
 ALT_GEN = 5
-
-class CatchLogs(object):
-    def setUp(self):
-        self.old_logger = oidutil.log
-        oidutil.log = self.gotLogMessage
-        self.messages = []
-
-    def gotLogMessage(self, message):
-        self.messages.append(message)
-
-    def tearDown(self):
-        oidutil.log = self.old_logger
 
 class TestProtocolError(unittest.TestCase):
     def test_browserWithReturnTo(self):
@@ -1999,10 +1988,10 @@ class TestSignatory(unittest.TestCase, CatchLogs):
         self.failIf(self.messages, self.messages)
 
     def test_getAssocExpired(self):
-        assoc_handle = self.makeAssoc(dumb=True, lifetime=-10)
+	assoc_handle = self.makeAssoc(dumb=True, lifetime=-10)
         assoc = self.signatory.getAssociation(assoc_handle, True)
         self.failIf(assoc, assoc)
-        self.failUnless(self.messages)
+	self.failUnless(self.messages)
 
     def test_getAssocInvalid(self):
         ah = 'no-such-handle'


### PR DESCRIPTION
This commit updates the code to use the python logging module rather than oidutils.log. The later is still left-in for compatibility reasons. The tests were updated accordingly.

According to the documentation python logging is available since python 2.3 which is line with the declared compatibility of python-openid and using logging makes is play nicer in complex run environments (like google app engine).
