### PR TITLE
Module Level Logging

### DIFF
--- a/background-associations.txt
+++ b/background-associations.txt
@@ -71,21 +71,24 @@ could make the background fetcher listen for inserts into the queue.
 
 The background fetcher needs to do something similar to the following::
 
+  import logging
+  log = logging.getLogger(__name__)
+
   def refresh(consumer, endpoint):
       if consumer.store.getAssociation(endpoint.server_url):
-          logging.info("We don't need to associate with %r", endpoint.server_url)
+          log.info("We don't need to associate with %r" % endpoint.server_url)
           return
 
-      logging.info("Associating with %r", endpoint.server_url)
+      log.info("Associating with %r" % endpoint.server_url)
       now = time.time()
       assoc = consumer._negotiateAssociation(endpoint)
       if assoc:
           elapsed = time.time() - now
-          logging.info('(%0.2f seconds) Associated with %r', elapsed,
-                       endpoint.server_url)
+          log.info('(%0.2f seconds) Associated with %r' % (elapsed,
+                       endpoint.server_url))
           consumer.store.storeAssociation(endpoint.server_url, assoc)
       else:
-          logging.error('Failed to make an association with %r',
+          log.error('Failed to make an association with %r' %
                         endpoint.server_url)
 
 The code in this example logs the amount of time that the association

--- a/openid/consumer/discover.py
+++ b/openid/consumer/discover.py
@@ -37,6 +37,8 @@ OPENID_1_0_TYPE = 'http://openid.net/signon/1.0'
 from openid.message import OPENID1_NS as OPENID_1_0_MESSAGE_NS
 from openid.message import OPENID2_NS as OPENID_2_0_MESSAGE_NS
 
+log = logging.getLogger(__name__)
+
 class OpenIDServiceEndpoint(object):
     """Object representing an OpenID service endpoint.
 
@@ -426,7 +428,7 @@ def discoverXRI(iname):
         for service_element in services:
             endpoints.extend(flt.getServiceEndpoints(iname, service_element))
     except XRDSError:
-        logging.exception('xrds error on ' + iname)
+        log.exception('xrds error on %s' % iname)
 
     for endpoint in endpoints:
         # Is there a way to pass this through the filter to the endpoint

--- a/openid/extensions/sreg.py
+++ b/openid/extensions/sreg.py
@@ -69,6 +69,8 @@ data_fields = {
     'timezone':'Time Zone',
     }
 
+log = logging.getLogger(__name__)
+
 def checkFieldName(field_name):
     """Check to see that the given value is a valid simple
     registration data field name.
@@ -95,7 +97,7 @@ ns_uri = ns_uri_1_1
 try:
     registerNamespaceAlias(ns_uri_1_1, 'sreg')
 except NamespaceAliasRegistrationError, e:
-    logging.exception('registerNamespaceAlias(%r, %r) failed: %s' % (ns_uri_1_1,
+    log.exception('registerNamespaceAlias(%r, %r) failed: %s' % (ns_uri_1_1,
                                                                'sreg', str(e),))
 
 def supportsSReg(endpoint):

--- a/openid/kvform.py
+++ b/openid/kvform.py
@@ -3,6 +3,8 @@ __all__ = ['seqToKV', 'kvToSeq', 'dictToKV', 'kvToDict']
 import types
 import logging
 
+log = logging.getLogger(__name__)
+
 class KVFormError(ValueError):
     pass
 
@@ -21,7 +23,7 @@ def seqToKV(seq, strict=False):
         if strict:
             raise KVFormError(formatted)
         else:
-            logging.warn(formatted)
+            log.warn(formatted)
 
     lines = []
     for k, v in seq:
@@ -72,7 +74,7 @@ def kvToSeq(data, strict=False):
         if strict:
             raise KVFormError(formatted)
         else:
-            logging.warn(formatted)
+            log.warn(formatted)
 
     lines = data.split('\n')
     if lines[-1]:

--- a/openid/oidutil.py
+++ b/openid/oidutil.py
@@ -8,8 +8,6 @@ interesting.
 __all__ = ['log', 'appendArgs', 'toBase64', 'fromBase64', 'autoSubmitHTML', 'toUnicode']
 
 import binascii
-import sys
-import urlparse
 import logging
 
 from urllib import urlencode
@@ -21,6 +19,8 @@ elementtree_modules = [
     'cElementTree',
     'elementtree.ElementTree',
     ]
+
+log = logging.getLogger(__name__)
 
 def toUnicode(value):
     """Returns the given argument as a unicode object.
@@ -73,13 +73,14 @@ def importElementTree(module_names=None):
             pass
         else:
             # Make sure it can actually parse XML
+            xml_test = '<unused/>'
             try:
-                ElementTree.XML('<unused/>')
+                ElementTree.XML(xml_test)
             except (SystemExit, MemoryError, AssertionError):
                 raise
             except:
-                logging.exception('Not using ElementTree library %r because it failed to '
-                    'parse a trivial document: %s' % mod_name)
+                log.exception('Not using ElementTree library %r because it failed to '
+                    'parse a trivial document: %s' % (mod_name, xml_test))
             else:
                 return ElementTree
     else:
@@ -91,7 +92,7 @@ def importElementTree(module_names=None):
 def log(message, level=0):
     """Handle a log message from the OpenID library.
 
-    This is a legacy function which redirects to logging.error.
+    This is a legacy function which redirects to log.error.
     The logging module should be used instead of this
 
     @param message: A string containing a debugging message from the
@@ -106,7 +107,7 @@ def log(message, level=0):
     @returns: Nothing.
     """
 
-    logging.error("This is a legacy log message, please use the "
+    log.error("This is a legacy log message, please use the "
       "logging module. Message: %s", message)
 
 def appendArgs(url, args):

--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -143,6 +143,8 @@ ENCODE_HTML_FORM = ('HTML form',)
 
 UNUSED = None
 
+log = logging.getLogger(__name__)
+
 class OpenIDRequest(object):
     """I represent an incoming OpenID request.
 
@@ -421,8 +423,8 @@ class AssociateRequest(OpenIDRequest):
         if message.isOpenID1():
             session_type = message.getArg(OPENID_NS, 'session_type')
             if session_type == 'no-encryption':
-                logging.warn('Received OpenID 1 request with a no-encryption '
-                            'assocaition session type. Continuing anyway.')
+                log.warn('Received OpenID 1 request with a no-encryption '
+                            'association session type. Continuing anyway.')
             elif not session_type:
                 session_type = 'no-encryption'
         else:
@@ -1171,15 +1173,14 @@ class Signatory(object):
         """
         assoc = self.getAssociation(assoc_handle, dumb=True)
         if not assoc:
-            logging.error("failed to get assoc with handle %r to verify "
-                        "message %r"
-                        % (assoc_handle, message))
+            log.error("failed to get assoc with handle %r to verify "
+                        "message %r" % (assoc_handle, message))
             return False
 
         try:
             valid = assoc.checkMessageSignature(message)
         except ValueError, ex:
-            logging.exception("Error in verifying %s with %s: %s" % (message,
+            log.exception("Error in verifying %s with %s: %s" % (message,
                                                                assoc,
                                                                ex))
             return False
@@ -1286,7 +1287,7 @@ class Signatory(object):
             key = self._normal_key
         assoc = self.store.getAssociation(key, assoc_handle)
         if assoc is not None and assoc.expiresIn <= 0:
-            logging.info("requested %sdumb key %r is expired (by %s seconds)" %
+            log.info("requested %sdumb key %r is expired (by %s seconds)" %
                         ((not dumb) and 'not-' or '',
                          assoc_handle, assoc.expiresIn))
             if checkExpiration:

--- a/openid/server/trustroot.py
+++ b/openid/server/trustroot.py
@@ -24,6 +24,8 @@ from urlparse import urlparse, urlunparse
 import re
 import logging
 
+log = logging.getLogger(__name__)
+
 ############################################
 _protocols = ['http', 'https']
 _top_level_domains = [
@@ -443,12 +445,12 @@ def verifyReturnTo(realm_str, return_to, _vrfy=getAllowedReturnURLs):
     try:
         allowable_urls = _vrfy(realm.buildDiscoveryURL())
     except RealmVerificationRedirected, err:
-        logging.exception(str(err))
+        log.exception(str(err))
         return False
 
     if returnToMatches(allowable_urls, return_to):
         return True
     else:
-        logging.error("Failed to validate return_to %r for realm %r, was not "
+        log.error("Failed to validate return_to %r for realm %r, was not "
                     "in %s" % (return_to, realm_str, allowable_urls))
         return False

--- a/openid/store/filestore.py
+++ b/openid/store/filestore.py
@@ -59,6 +59,8 @@ except NameError:
 else:
     _isFilenameSafe = set(_filename_allowed).__contains__
 
+log = logging.getLogger(__name__)
+
 def _safe64(s):
     h64 = oidutil.toBase64(cryptutil.sha1(s))
     h64 = h64.replace('+', '_')
@@ -372,7 +374,7 @@ class FileOpenIDStore(OpenIDStore):
                 association_file = file(association_filename, 'rb')
             except IOError, why:
                 if why.errno == ENOENT:
-                    logging.exception("%s disappeared during %s._allAssocs" % (
+                    log.exception("%s disappeared during %s._allAssocs" % (
                         association_filename, self.__class__.__name__))
                 else:
                     raise


### PR DESCRIPTION
All of the logging was using `logging.warn()`, calling the logging library directly. This caused the logs to be logged to the root logger, thereby making it difficult to selectively filter the logs it produced.

I added `log = logging.getLogger(__name__)` to each logging file and changed the logging statements to `log.{LOG LEVEL}("message")` so they'd log to the appropriate logger.

I also cleaned up some of the logging.
