### PR TITLE
Support sending CheckID responses with different identifier

### DIFF
--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -820,17 +820,14 @@ class CheckIDRequest(OpenIDRequest):
                     normalized_request_identity = urinorm(self.identity)
                     normalized_answer_identity = urinorm(identity)
 
+                    # if identity has been changed, ensure that we don't
+                    # send back the same claimed_id.
                     if (normalized_request_identity !=
-                        normalized_answer_identity):
-                        raise ValueError(
-                            "Request was for identity %r, cannot reply "
-                            "with identity %r" % (self.identity, identity))
+                            normalized_answer_identity) and not claimed_id:
+                        claimed_id = identity
 
-                # The "identity" value in the response shall always be
-                # the same as that in the request, otherwise the RP is
-                # likely to not validate the response.
-                response_identity = self.identity
-                response_claimed_id = self.claimed_id
+                response_identity = identity or self.identity
+                response_claimed_id = claimed_id or self.claimed_id
             else:
                 if identity:
                     raise ValueError(


### PR DESCRIPTION
This is handled properly by a fair number of OpenID 2.0 RPs. It allows the provider to support identifier selection even if a different identifier was passed.

You can observe this e.g. with Google accounts. For example, try to login to OpenID 2-capable site (I tested using the openid-ldap.org test script and stackoverflow) using the identifier `mgorny.alt.pl`. After logging in to your Google account, Google will allow you to choose that account and the site will use it rather than one specified in domain delegation.
