### PR TITLE
Add GAE Memcache Store

### DIFF
--- a/openid/oidutil.py
+++ b/openid/oidutil.py
@@ -8,19 +8,26 @@ interesting.
 __all__ = ['log', 'appendArgs', 'toBase64', 'fromBase64', 'autoSubmitHTML', 'toUnicode']
 
 import binascii
-import sys
-import urlparse
 import logging
 
 from urllib import urlencode
 
 elementtree_modules = [
+    'defusedxml.lxml',
     'lxml.etree',
     'xml.etree.cElementTree',
     'xml.etree.ElementTree',
     'cElementTree',
     'elementtree.ElementTree',
     ]
+
+try:
+    import defusedxml
+    defusedxml.defuse_stdlib()
+except ImportError:
+    logging.warning('defusedxml not found! It is recommended that you install defusedxml '
+        'to avoid vulnerabilities related to XML parsing. For more details see '
+        'https://pypi.python.org/pypi/defusedxml/')
 
 def toUnicode(value):
     """Returns the given argument as a unicode object.

--- a/openid/store/gaecachestore.py
+++ b/openid/store/gaecachestore.py
@@ -1,0 +1,98 @@
+"""
+An OpenIDStore implementation that uses the Google App Engine
+memcache servers as its backing store.
+
+Stores associations, nonces, and authentication tokens.
+
+OpenIDStore is an interface from JanRain's OpenID python library:
+    http://openidenabled.com/python-openid/
+
+For more, see openid/store/interface.py in that library.
+"""
+
+import datetime
+import pickle
+
+from openid.store.interface import OpenIDStore
+from google.appengine.api import memcache
+
+_GAE_MEMCACHE_NAMESPACE = 'openid_store'
+
+class ServerAssocs(object):
+    def __init__(self):
+        self.assocs = {}
+
+    def set(self, assoc):
+        self.assocs[assoc.handle] = assoc
+
+    def get(self, handle):
+        return self.assocs.get(handle)
+
+    def remove(self, handle):
+        try:
+            del self.assocs[handle]
+        except KeyError:
+            return False
+        else:
+            return True
+
+    def best(self):
+        """Returns association with the oldest issued date.
+
+        or None if there are no associations.
+        """
+        best = None
+        for assoc in self.assocs.values():
+            if best is None or best.issued < assoc.issued:
+                best = assoc
+        return best
+
+    def empty(self):
+        return len(self.assocs) == 0
+
+class MemcacheStore(OpenIDStore):
+    def getAssocFromStore(self, server_url):
+        key = 'association_' + server_url
+        assoc = memcache.get(key, namespace=_GAE_MEMCACHE_NAMESPACE)
+        if assoc:
+            assoc = pickle.loads(assoc)
+        else:
+            assoc = ServerAssocs()
+        return assoc
+
+    def storeAssociation(self, server_url, association):
+        assoc = self.getAssocFromStore(server_url)
+        assoc.set(association)
+        key = 'association_' + server_url
+        memcache.set(key, pickle.dumps(assoc), namespace=_GAE_MEMCACHE_NAMESPACE)
+
+    def getAssociation(self, server_url, handle=None):
+        assoc = self.getAssocFromStore(server_url)
+        if handle:
+            return assoc.get(handle)
+        else:
+            return assoc.best()
+
+    def removeAssociation(self, server_url, handle):
+        assoc = self.getAssocFromStore(server_url)
+        assoc.remove(handle)
+        key = 'association_' + server_url
+        if assoc.empty():
+            memcache.delete(key)
+        else:
+            memcache.set(key, pickle.dumps(assoc), namespace=_GAE_MEMCACHE_NAMESPACE)
+
+    def storeNonce(self, nonce):
+        key = 'nonce_' + nonce
+        memcache.set(key, datetime.datetime.now(), namespace=_GAE_MEMCACHE_NAMESPACE)
+
+    def useNonce(self, nonce):
+        key = 'nonce_' + nonce
+        expiry = memcache.get(key, namespace=_GAE_MEMCACHE_NAMESPACE)
+        if expiry:
+            memcache.delete(key, namespace=_GAE_MEMCACHE_NAMESPACE)
+        if expiry:
+            return expiry >= datetime.datetime.now() - datetime.timedelta(hours=6)
+        else:
+            return False
+


### PR DESCRIPTION
Adds a store which saves the information to the memcache servers provided by Google Appengine when the code is running on this platform. This can be a good compromise between speed and data durability.
