### PR TITLE
Making Message.__eq__ better

### DIFF
--- a/openid/message.py
+++ b/openid/message.py
@@ -490,7 +490,7 @@ class Message(object):
                                self.args)
 
     def __eq__(self, other):
-        return self.args == other.args
+        return hasattr(other, 'args') and self.args == other.args
 
 
     def __ne__(self, other):


### PR DESCRIPTION
Allows Messages to be compared with objects with no args attribute.
