### PR TITLE
Fix a bug where the request failed when upstream sends multiple HTTP/1.1 100 Continue messages

### DIFF
--- a/openid/fetchers.py
+++ b/openid/fetchers.py
@@ -253,7 +253,7 @@ class CurlHTTPFetcher(HTTPFetcher):
 
         # Remove the status line from the beginning of the input
         unused_http_status_line = header_file.readline().lower ()
-        if unused_http_status_line.startswith('http/1.1 100 '):
+        while unused_http_status_line.startswith('http/1.1 100 '):
             unused_http_status_line = header_file.readline()
             unused_http_status_line = header_file.readline()
 

--- a/openid/fetchers.py
+++ b/openid/fetchers.py
@@ -253,7 +253,7 @@ class CurlHTTPFetcher(HTTPFetcher):
 
         # Remove the status line from the beginning of the input
         unused_http_status_line = header_file.readline().lower ()
-        while unused_http_status_line.startswith('http/1.1 100 '):
+        while unused_http_status_line.startswith('http/1.1 1'):
             unused_http_status_line = header_file.readline()
             unused_http_status_line = header_file.readline()
 


### PR DESCRIPTION
Please note that this IS valid according to RFC2616, section 10.1:
 A client MUST be prepared to accept one or more 1xx status responses prior to a regular response, even if the client does not expect a 100 (Continue) status message. Unexpected 1xx status responses MAY be ignored by a user agent.
