### PR TITLE
fixed a problem, that the "continue" page of the example

### DIFF
--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -208,6 +208,9 @@ class OpenIDRequestHandler(BaseHTTPRequestHandler):
                         form_tag_attrs={'id':'openid_message'},
                         immediate=immediate)
 
+                    self.send_response(200)
+                    self.send_header('Content-Type', "text/html")
+                    self.end_headers()
                     self.wfile.write(form_html)
 
     def requestRegistrationData(self, request):


### PR DESCRIPTION
consumer would not be displayed as html in firefox.

The continue button would be displayed as text/plain in the browser.
