### PR TITLE
Send a response code so the http response is properly formatted

### DIFF
--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -207,7 +207,7 @@ class OpenIDRequestHandler(BaseHTTPRequestHandler):
                         trust_root, return_to,
                         form_tag_attrs={'id':'openid_message'},
                         immediate=immediate)
-
+                    self.send_response(200)
                     self.wfile.write(form_html)
 
     def requestRegistrationData(self, request):


### PR DESCRIPTION
Without this, using the consumer simply shows the html "raw" output, instead of a "live" page.

