### PR TITLE
Updating python_requires and test for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ INSTALLATION
 
 To install the base library, just run the following command:
 
-sudo pip install -e .
+pip install -e .
 
 To install this module, you'll need to install 'pip' and its related
 dependencies from your distribution's package repository.  These are

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ INSTALLATION
 
 To install the base library, just run the following command:
 
-python setup.py install
+sudo pip install -e .
 
-To run setup.py you need the distutils module from the Python standard
-library; some distributions package this seperately in a "python-dev"
-package.
+To install this module, you'll need to install 'pip' and its related
+dependencies from your distribution's package repository.  These are
+typically called 'python-setuptools' and 'python-wheel'
 
 
 GETTING STARTED

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,3 @@ formats=gztar,zip
 
 [options]
 python_requires = >=2.6,<3
-setup_requires = setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ force_manifest=1
 formats=gztar,zip
 
 [options]
-python_requires = >2.6,<3
+python_requires = >=2.6,<3
 setup_requires = setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [sdist]
 force_manifest=1
 formats=gztar,zip
+
+[options]
+python_requires = >2.6,<3
+setup_requires = setuptools

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,15 @@ except ImportError:
 if 'sdist' in sys.argv:
     os.system('./admin/makedoc')
 
+if not sys.version_info[0] == 2:
+    sys.exit("Sorry, Python 3 is not supported. Please use python3-openid")
+
 version = '[library version:2.2.5]'[17:-1]
 
 setup(
     name='python-openid',
     version=version,
+    python_requires=">2.6.*,<3.0.*",
     description='OpenID support for servers and consumers.',
     long_description='''This is a set of Python packages to support use of
 the OpenID decentralized identity system in your application.  Want to enable

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ and support for a variety of storage back-ends.''',
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration :: Authentication/Directory",
     ],
-    python_requires='>2.6*,<3'
+    python_requires='>=2.6,<3'
     )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 try:
     from setuptools import setup
@@ -9,15 +9,11 @@ except ImportError:
 if 'sdist' in sys.argv:
     os.system('./admin/makedoc')
 
-if not sys.version_info[0] == 2:
-    sys.exit("Sorry, Python 3 is not supported. Please use python3-openid")
-
 version = '[library version:2.2.5]'[17:-1]
 
 setup(
     name='python-openid',
     version=version,
-    python_requires=">2.6.*,<3.0.*",
     description='OpenID support for servers and consumers.',
     long_description='''This is a set of Python packages to support use of
 the OpenID decentralized identity system in your application.  Want to enable
@@ -50,4 +46,5 @@ and support for a variety of storage back-ends.''',
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration :: Authentication/Directory",
     ],
+    python_requires='>2.6*,<3'
     )


### PR DESCRIPTION
This currently installs under Python 3, but map() in Python 3 returns a map object, not a list as it did in Python 2. Users with py3 should use python3-openid, not python-openid.  